### PR TITLE
Fix reports for non-multistore stores

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -10,13 +10,19 @@ Spree::Admin::ReportsController.class_eval do
   end
   prepend SimpleReport
 
+  # load helper method to views & controller
+  helper "spree/admin/simple_reports"
+  include Spree::Admin::SimpleReportsHelper
+
   def total_sales_of_each_product
     @variants = Spree::Variant.joins(:product, line_items: :order)
                 .select("spree_variants.id, spree_products.slug as product_id, spree_products.name as name, sku, SUM(spree_line_items.quantity) as quantity, SUM((spree_line_items.price * spree_line_items.quantity) + spree_line_items.adjustment_total) as total_price")
-                .where("spree_orders.store_id" => store_id)
                 .where.not('spree_orders.created_at' => nil)
                 .where('spree_orders.created_at' => [created_at_gt..created_at_lt])
                 .group('spree_variants.id, spree_products.id, spree_products.name')
+    if supports_store_id?
+      @variants = @variants.where("spree_orders.store_id" => store_id)
+    end
   end
 
   def ten_days_order_count

--- a/app/helpers/spree/admin/simple_reports_helper.rb
+++ b/app/helpers/spree/admin/simple_reports_helper.rb
@@ -1,0 +1,5 @@
+module Spree::Admin::SimpleReportsHelper
+  def supports_store_id?
+    Spree::Order.column_names.include? "store_id"
+  end
+end

--- a/app/views/spree/admin/reports/total_sales_of_each_product.html.haml
+++ b/app/views/spree/admin/reports/total_sales_of_each_product.html.haml
@@ -10,9 +10,10 @@
 
 - content_for :table_filter do
   = form_tag spree.total_sales_of_each_product_admin_reports_path do
-    %div.select-filter.field.align-center
-      = label_tag nil, Spree.t(:store), class: 'inline'
-      = select_tag :store_id, options_from_collection_for_select(Spree::Store.all, "id", "name", params[:store_id]), prompt: 'All'
+    - if supports_store_id?
+      %div.select-filter.field.align-center
+        = label_tag nil, Spree.t(:store), class: 'inline'
+        = select_tag :store_id, options_from_collection_for_select(Spree::Store.all, "id", "name", params[:store_id]), prompt: 'All'
     %div.date-range-filter.field.align-center
       = label_tag nil, Spree.t(:start), class: 'inline'
       = text_field_tag :created_at_gt, datepicker_field_value(params[:created_at_gt]), class: 'datepicker datepicker-from'


### PR DESCRIPTION
Running spree_simple_reports on a store without multi-store support
raises an exception because it tries to query an invalid database column:
spree_order.store_id.

This patch checks the Spree::Order to see if it defines that column, and
avoids using it if it does not exist.
