### PR TITLE
Fixes for total_sales_of_each_product

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -20,7 +20,7 @@ Spree::Admin::ReportsController.class_eval do
                 .where.not('spree_orders.created_at' => nil)
                 .where('spree_orders.created_at' => [created_at_gt..created_at_lt])
                 .group('spree_variants.id, spree_products.id, spree_products.name')
-    if supports_store_id?
+    if supports_store_id? && store_id
       @variants = @variants.where("spree_orders.store_id" => store_id)
     end
   end
@@ -50,7 +50,7 @@ Spree::Admin::ReportsController.class_eval do
   end
 
   def store_id
-    params[:store_id].blank? ? Spree::Store.all.map(&:id) : params[:store_id]
+    params[:store_id].presence
   end
 
   def created_at_gt

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -1,71 +1,75 @@
-Spree::Admin::ReportsController.class_eval do
+module Spree
+  module Admin
+    ReportsController.class_eval do
 
-  module SimpleReport
-    def initialize
-      Spree::Admin::ReportsController.add_available_report!(:total_sales_of_each_product)
-      Spree::Admin::ReportsController.add_available_report!(:ten_days_order_count)
-      Spree::Admin::ReportsController.add_available_report!(:thirty_days_order_count)
-      super
-    end
-  end
-  prepend SimpleReport
+      module SimpleReport
+        def initialize
+          ReportsController.add_available_report!(:total_sales_of_each_product)
+          ReportsController.add_available_report!(:ten_days_order_count)
+          ReportsController.add_available_report!(:thirty_days_order_count)
+          super
+        end
+      end
+      prepend SimpleReport
 
-  # load helper method to views & controller
-  helper "spree/admin/simple_reports"
-  include Spree::Admin::SimpleReportsHelper
+      # load helper method to views & controller
+      helper "spree/admin/simple_reports"
+      include SimpleReportsHelper
 
-  def total_sales_of_each_product
-    @variants = Spree::Variant.joins(:product, line_items: :order)
-                .select("spree_variants.id, spree_products.slug as product_id, spree_products.name as name, sku, SUM(spree_line_items.quantity) as quantity, SUM((spree_line_items.price * spree_line_items.quantity) + spree_line_items.adjustment_total) as total_price")
-                .where.not('spree_orders.created_at' => nil)
-                .where('spree_orders.created_at' => [created_at_gt..created_at_lt])
-                .group('spree_variants.id, spree_products.id, spree_products.name')
-    if supports_store_id? && store_id
-      @variants = @variants.where("spree_orders.store_id" => store_id)
-    end
-  end
+      def total_sales_of_each_product
+        @variants = Variant.joins(:product, line_items: :order)
+                    .select("spree_variants.id, spree_products.slug as product_id, spree_products.name as name, sku, SUM(spree_line_items.quantity) as quantity, SUM((spree_line_items.price * spree_line_items.quantity) + spree_line_items.adjustment_total) as total_price")
+                    .merge(Order.complete.completed_between(completed_at_gt, completed_at_lt))
+                    .group("spree_variants.id, spree_products.id, spree_products.name")
+        if supports_store_id? && store_id
+          @variants = @variants.where("spree_orders.store_id" => store_id)
+        end
+      end
 
-  def ten_days_order_count
-    @counts = n_day_order_count(10)
-  end
+      def ten_days_order_count
+        @counts = n_day_order_count(10)
+      end
 
-  def thirty_days_order_count
-    @counts = n_day_order_count(30)
-  end
+      def thirty_days_order_count
+        @counts = n_day_order_count(30)
+      end
 
-  private
+      private
 
-  def n_day_order_count(n)
-    counts = []
-    n.times do |i|
-      counts << {
-        number: i,
-        date: i.days.ago.to_date,
-        count: Spree::Order.complete
-          .where("completed_at >= ?",i.days.ago.beginning_of_day)
-          .where("completed_at <= ?",i.days.ago.end_of_day).count
-      }
-    end
-    counts
-  end
+      def n_day_order_count(n)
+        counts = []
+        n.times do |i|
+          counts << {
+            number: i,
+            date: i.days.ago.to_date,
+            count: Order.complete
+              .where("completed_at >= ?",i.days.ago.beginning_of_day)
+              .where("completed_at <= ?",i.days.ago.end_of_day).count
+          }
+        end
+        counts
+      end
 
-  def store_id
-    params[:store_id].presence
-  end
+      def store_id
+        params[:store_id].presence
+      end
 
-  def created_at_gt
-    params[:created_at_gt] = if params[:created_at_gt].blank?
-      Date.today.beginning_of_month
-    else
-      Date.parse(params[:created_at_gt])
-    end
-  end
+      def completed_at_gt
+        params[:completed_at_gt] = if params[:completed_at_gt].blank?
+          Date.today.beginning_of_month
+        else
+          Date.parse(params[:completed_at_gt])
+        end
+      end
 
-  def created_at_lt
-    params[:created_at_lt] = if params[:created_at_lt].blank?
-      Date.today
-    else
-      Date.parse(params[:created_at_lt])
+      def completed_at_lt
+        params[:completed_at_lt] = if params[:completed_at_lt].blank?
+          Date.today
+        else
+          Date.parse(params[:completed_at_lt])
+        end
+      end
+
     end
   end
 end

--- a/app/views/spree/admin/reports/total_sales_of_each_product.html.erb
+++ b/app/views/spree/admin/reports/total_sales_of_each_product.html.erb
@@ -22,10 +22,10 @@
     <% end %>
     <div class="date-range-filter field align-center">
       <%= label_tag nil, Spree.t(:start), class: 'inline' %>
-      <%= text_field_tag :created_at_gt, datepicker_field_value(params[:created_at_gt]), class: 'datepicker datepicker-from' %>
+      <%= text_field_tag :completed_at_gt, datepicker_field_value(params[:completed_at_gt]), class: 'datepicker datepicker-from' %>
       <span class="range-divider">
         <i class="fa fa-arrow-right"></i>
-        <%= text_field_tag :created_at_lt, datepicker_field_value(params[:created_at_lt]), class: 'datepicker datepicker-to' %>
+        <%= text_field_tag :completed_at_lt, datepicker_field_value(params[:completed_at_lt]), class: 'datepicker datepicker-to' %>
         <%= label_tag nil, Spree.t(:end), class: 'inline' %>
       </span>
     </div>


### PR DESCRIPTION
important changes to that report: allow orders with spree_id: nil (i have this situation on spree 2.4) and filter order by completed_at, not created_at
