### PR TITLE
Fix completed_at_lt date

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -64,9 +64,9 @@ module Spree
 
       def completed_at_lt
         params[:completed_at_lt] = if params[:completed_at_lt].blank?
-          Date.today
+          Date.today.end_of_day
         else
-          Date.parse(params[:completed_at_lt])
+          Date.parse(params[:completed_at_lt]).end_of_day
         end
       end
 


### PR DESCRIPTION
If you pull a report where the start and end are the same date, you get
no orders because they resolve to the same time.  Instead, we should use
the "end_of_day" of the end date to ensure that it pulls orders for only
one day.